### PR TITLE
Modify MySQL root host to allow all 10.* IP addresses.

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -4,7 +4,7 @@ services:
   mysql:
     image: mysql/mysql-server:8.0
     environment:
-      MYSQL_ROOT_HOST: "10.0.0.2"
+      MYSQL_ROOT_HOST: "10.%"
       MYSQL_ROOT_PASSWORD: rootpass
     ports:
     - "23306:3306/tcp"


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/blob/main/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This change modifies the range of IP addresses for MySQL Root Host addresses in the `docker-compose.yml` file.

#### Why make this change?

To slacken the range of IP addresses for MySQL Root Host address so that the `docker-compose.yml` file can be applied in various engines (e.g. docker, docker-compose, etc.)

#### Is there anything you are unsure about?

No.

#### What issues does this relate to?

N/A
